### PR TITLE
feat: add types and account for jsDoc as array.

### DIFF
--- a/.changeset/long-bees-repair.md
+++ b/.changeset/long-bees-repair.md
@@ -1,0 +1,5 @@
+---
+"cem-plugin-readonly": patch
+---
+
+Add types and fix readonly ts as query

--- a/plugins/cem-plugin-readonly/index.d.ts
+++ b/plugins/cem-plugin-readonly/index.d.ts
@@ -1,0 +1,2 @@
+import type { Plugin } from '@custom-elements-manifest/analyzer';
+export declare function readonlyPlugin(): Plugin;

--- a/plugins/cem-plugin-readonly/index.js
+++ b/plugins/cem-plugin-readonly/index.js
@@ -10,7 +10,7 @@ import { isStaticMember } from '@custom-elements-manifest/analyzer/src/utils/ast
 function isReadonly(node, ts) {
   return (
     node.modifiers?.some?.(x => x.kind === ts.SyntaxKind.ReadonlyKeyword) ||
-    node.jsDoc?.tags?.some?.(tag => tag.kind === ts.SyntaxKind.JSDocReadonlyTag)
+    node.jsDoc?.flatMap(i => i.tags).some(tag => tag?.kind === ts.SyntaxKind.JSDocReadonlyTag)
   );
 }
 


### PR DESCRIPTION
`node.jsDoc` presents as an array so I use `flatMap` to get into the listing of tags.  I was running into the scenario of decorating a lit property wasn't working.

```
  /**
   * Specify the selector of the content you want to capture the word-count from.  Whatever you enter into this attribute will be found using `document.querySelector(<for attribute value>)`.
   * @readonly
   */
  @property({ type: String, reflect: true }) for?: string;
```